### PR TITLE
fix: Resolve "objectsMap is undefined" error in canvas.getObjectAtPos…

### DIFF
--- a/src/objects.js
+++ b/src/objects.js
@@ -38,7 +38,7 @@
  * @property {boolean} [isSelected] - (Consider if this is a local UI state or part of object data)
  */
 
-let currentObjects = new Map();
+export const currentObjects = new Map();
 
 // Basic UUID generator
 const generateUUID = () => {


### PR DESCRIPTION
…ition

This commit fixes a TypeError that occurred when `canvas.getObjectAtPosition` was called from `main.js`. The `objectsMap` parameter was undefined because the `currentObjects` Map in `src/objects.js` was not being exported.

The fix involves:
- Modifying `src/objects.js` to export the `currentObjects` Map (changed from a module-local `let` to an `export const`).

This change ensures that `main.js`, which imports the `objects` module as a namespace, can now correctly access `objects.currentObjects` and pass the valid Map to `canvas.getObjectAtPosition`. This should resolve the console error and allow object selection features to function correctly.