### PR TITLE
fix: Make getObjectAtPosition robust and fix selection issues

### DIFF
--- a/src/__tests__/canvas.test.js
+++ b/src/__tests__/canvas.test.js
@@ -308,3 +308,187 @@ describe('Canvas drawVTT Highlight Logic', () => {
     );
   });
 });
+
+// --- Tests for getObjectAtPosition ---
+describe('getObjectAtPosition Logic', () => {
+  let consoleWarnSpy;
+  let consoleErrorSpy;
+
+  beforeEach(() => {
+    // Suppress console output for these tests and spy on calls
+    consoleWarnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+    consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    // No canvas.js internal state needs resetting for getObjectAtPosition usually,
+    // as it's a pure function with respect to canvas module state.
+  });
+
+  afterEach(() => {
+    // Restore console functions
+    consoleWarnSpy.mockRestore();
+    consoleErrorSpy.mockRestore();
+  });
+
+  // Helper to create an objectsMap
+  const createObjectsMap = (objectsArray) => {
+    const map = new Map();
+    objectsArray.forEach(obj => map.set(obj.id, obj));
+    return map;
+  };
+
+  // 1. Valid Hits
+  test('Valid Hit: Non-rotated rectangle center', () => {
+    const rect = { id: 'rect1', shape: 'rectangle', x: 10, y: 10, width: 100, height: 50, rotation: 0, zIndex: 0 };
+    const objectsMap = createObjectsMap([rect]);
+    const result = getObjectAtPosition(60, 35, objectsMap); // Center: 10+100/2=60, 10+50/2=35
+    expect(result).toBe('rect1');
+    expect(consoleWarnSpy).not.toHaveBeenCalled();
+    expect(consoleErrorSpy).not.toHaveBeenCalled();
+  });
+
+  test('Valid Hit: Rotated rectangle (45deg) - hitting original center', () => {
+    // For a rectangle 100x100 at (0,0) rotated 45deg, its original center (50,50) is still the point of rotation.
+    // The new getObjectAtPosition logic transforms the click point, not the object.
+    // So, clicking the world-space (50,50) should still be a hit if it's the center of rotation.
+    const rect = { id: 'rectR', shape: 'rectangle', x: 0, y: 0, width: 100, height: 100, rotation: 45, zIndex: 0 };
+    const objectsMap = createObjectsMap([rect]);
+    // Center of the rectangle is (0 + 100/2, 0 + 100/2) = (50, 50)
+    // This point remains the center of the object's bounding box for hit detection after rotation.
+    const result = getObjectAtPosition(50, 50, objectsMap);
+    expect(result).toBe('rectR');
+    expect(consoleWarnSpy).not.toHaveBeenCalled();
+  });
+  
+  test('Valid Hit: Rotated rectangle (90deg) - hitting a known internal point', () => {
+    // Rectangle at (10,10), size 100x50, rotated 90 degrees.
+    // Original corners: (10,10), (110,10), (10,60), (110,60)
+    // Center of rotation: (10+50, 10+25) = (60, 35)
+    // After 90deg rotation, it effectively becomes a 50x100 rectangle.
+    // Its new world-space bounding box would be tricky to calculate by hand quickly,
+    // but a click on its center of rotation (60,35) should always be a hit.
+    const rect = { id: 'rectR90', shape: 'rectangle', x: 10, y: 10, width: 100, height: 50, rotation: 90, zIndex: 0 };
+    const objectsMap = createObjectsMap([rect]);
+    const result = getObjectAtPosition(60, 35, objectsMap); // Click its center of rotation
+    expect(result).toBe('rectR90');
+    expect(consoleWarnSpy).not.toHaveBeenCalled();
+  });
+
+
+  test('Valid Hit: Circle center', () => {
+    const circ = { id: 'circ1', shape: 'circle', x: 10, y: 10, width: 50, height: 50, rotation: 0, zIndex: 0 }; // width/height is diameter
+    const objectsMap = createObjectsMap([circ]);
+    const result = getObjectAtPosition(35, 35, objectsMap); // Center: 10+50/4=22.5 (radius) -> 10+25 = 35
+    expect(result).toBe('circ1');
+    expect(consoleWarnSpy).not.toHaveBeenCalled();
+  });
+
+  test('Valid Hit: Overlapping objects, higher zIndex wins', () => {
+    const rectLowZ = { id: 'rectLow', shape: 'rectangle', x: 10, y: 10, width: 100, height: 50, rotation: 0, zIndex: 0 };
+    const rectHighZ = { id: 'rectHigh', shape: 'rectangle', x: 15, y: 15, width: 100, height: 50, rotation: 0, zIndex: 1 };
+    const objectsMap = createObjectsMap([rectLowZ, rectHighZ]);
+    const result = getObjectAtPosition(60, 35, objectsMap); // Point within both, e.g., center of rectLowZ
+    expect(result).toBe('rectHigh');
+    expect(consoleWarnSpy).not.toHaveBeenCalled();
+  });
+
+  // 2. Misses
+  test('Miss: Clicking far from any object', () => {
+    const rect = { id: 'rect1', shape: 'rectangle', x: 10, y: 10, width: 100, height: 50, rotation: 0, zIndex: 0 };
+    const objectsMap = createObjectsMap([rect]);
+    const result = getObjectAtPosition(500, 500, objectsMap);
+    expect(result).toBeNull();
+    expect(consoleWarnSpy).not.toHaveBeenCalled();
+    expect(consoleErrorSpy).not.toHaveBeenCalled();
+  });
+
+  // 3. Input Validation Tests
+  test('Input Validation: worldX is NaN', () => {
+    const objectsMap = createObjectsMap([]);
+    const result = getObjectAtPosition(NaN, 10, objectsMap);
+    expect(result).toBeNull();
+    expect(consoleErrorSpy).toHaveBeenCalledWith(expect.stringContaining('Invalid worldX or worldY input'), expect.anything());
+  });
+
+  test('Input Validation: worldY is NaN', () => {
+    const objectsMap = createObjectsMap([]);
+    const result = getObjectAtPosition(10, NaN, objectsMap);
+    expect(result).toBeNull();
+    expect(consoleErrorSpy).toHaveBeenCalledWith(expect.stringContaining('Invalid worldX or worldY input'), expect.anything());
+  });
+
+  test('Input Validation: objectsMap is null', () => {
+    const result = getObjectAtPosition(10, 10, null);
+    expect(result).toBeNull();
+    expect(consoleErrorSpy).toHaveBeenCalledWith(expect.stringContaining('objectsMap is not a Map'), null);
+  });
+  
+  test('Input Validation: objectsMap is an array', () => {
+    const result = getObjectAtPosition(10, 10, []);
+    expect(result).toBeNull();
+    expect(consoleErrorSpy).toHaveBeenCalledWith(expect.stringContaining('objectsMap is not a Map'), []);
+  });
+
+  // 4. Object Property Validation Tests
+  test('Object Validation: x is NaN', () => {
+    const badRect = { id: 'badRect', shape: 'rectangle', x: NaN, y: 10, width: 100, height: 50, rotation: 0, zIndex: 0 };
+    const objectsMap = createObjectsMap([badRect]);
+    const result = getObjectAtPosition(60, 35, objectsMap); // Try to click where center would be if x=10
+    expect(result).toBeNull(); // Should be skipped
+    expect(consoleWarnSpy).toHaveBeenCalledWith(expect.stringContaining('invalid x,y,width,or height'), expect.anything());
+  });
+
+  test('Object Validation: width is 0', () => {
+    const badRect = { id: 'badRectW0', shape: 'rectangle', x: 10, y: 10, width: 0, height: 50, rotation: 0, zIndex: 0 };
+    const objectsMap = createObjectsMap([badRect]);
+    const result = getObjectAtPosition(10, 35, objectsMap);
+    expect(result).toBeNull();
+    expect(consoleWarnSpy).toHaveBeenCalledWith(expect.stringContaining('non-positive width or height'), expect.anything());
+  });
+
+  test('Object Validation: height is -10', () => {
+    const badRect = { id: 'badRectHNeg', shape: 'rectangle', x: 10, y: 10, width: 50, height: -10, rotation: 0, zIndex: 0 };
+    const objectsMap = createObjectsMap([badRect]);
+    const result = getObjectAtPosition(35, 10, objectsMap);
+    expect(result).toBeNull();
+    expect(consoleWarnSpy).toHaveBeenCalledWith(expect.stringContaining('non-positive width or height'), expect.anything());
+  });
+  
+  test('Object Validation: rotation is NaN (should default to 0 and find object)', () => {
+    const rectRotNaN = { id: 'rectRotNaN', shape: 'rectangle', x: 10, y: 10, width: 100, height: 50, rotation: NaN, zIndex: 0 };
+    const objectsMap = createObjectsMap([rectRotNaN]);
+    // Click its center, assuming rotation defaults to 0 for hit detection
+    const result = getObjectAtPosition(60, 35, objectsMap);
+    expect(result).toBe('rectRotNaN'); // Found because rotation defaults to 0
+    expect(consoleWarnSpy).toHaveBeenCalledWith(expect.stringContaining('has NaN rotation. Defaulting to 0'), expect.anything());
+  });
+
+  test('Object Validation: Invalid item (null) in objectsMap values', () => {
+    const validRect = { id: 'valid', shape: 'rectangle', x: 10, y: 10, width: 20, height: 20, rotation: 0, zIndex: 0 };
+    const mapWithInvalid = new Map([
+        ['valid', validRect],
+        ['invalidKey', null]
+    ]);
+    // Click on the valid rectangle
+    const result = getObjectAtPosition(15, 15, mapWithInvalid);
+    expect(result).toBe('valid'); // Should still find the valid one
+    // A warning should be logged for the null object when iterating
+    expect(consoleWarnSpy).toHaveBeenCalledWith(expect.stringContaining('Encountered invalid object in sortedObjects'), null);
+  });
+  
+   test('Object Validation: Item in objectsMap is not an object (string)', () => {
+    const mapWithInvalid = new Map([
+        ['invalidKey', "i-am-a-string"]
+    ]);
+    const result = getObjectAtPosition(15, 15, mapWithInvalid);
+    expect(result).toBeNull();
+    expect(consoleWarnSpy).toHaveBeenCalledWith(expect.stringContaining('Encountered invalid object in sortedObjects'), "i-am-a-string");
+  });
+
+  test('Object with valid string numbers for dimensions/position', () => {
+    const rectStr = { id: 'rectStr', shape: 'rectangle', x: "10", y: "10", width: "100", height: "50", rotation: "0", zIndex: 0 };
+    const objectsMap = createObjectsMap([rectStr]);
+    const result = getObjectAtPosition(60, 35, objectsMap);
+    expect(result).toBe('rectStr');
+    expect(consoleWarnSpy).not.toHaveBeenCalled(); // parseFloat should handle these
+    expect(consoleErrorSpy).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
This commit addresses the issue where object selection was failing and all clicks resulted in panning. This was due to `getObjectAtPosition` in `src/canvas.js` consistently failing to identify objects.

The `getObjectAtPosition` function has been significantly enhanced:
- Added input validation for `worldX`, `worldY`, and the `objectsMap` itself.
- Implemented robust parsing and validation for critical object properties (`x`, `y`, `width`, `height`, `rotation`):
    - Ensures these are numeric and valid (e.g., positive dimensions).
    - Defaults `NaN` rotation values to 0.
    - Skips objects with invalid essential properties, logging warnings.
- Refined hit detection logic:
    - Uses a distinct, simplified AABB check for non-rotated rectangles.
    - Applies the previously reviewed transformation-based logic for rotated rectangles.
    - Circle hit detection remains standard.
- Included console logging for warnings, errors, and successful hits to aid future debugging.

Additionally, a new comprehensive suite of unit tests has been added to `src/__tests__/canvas.test.js` for `getObjectAtPosition`. These tests cover:
- Valid hit scenarios for different shapes (rectangles, rotated rectangles, circles).
- `zIndex` ordering.
- Misses on empty space.
- Input validation failures.
- Object property validation failures and graceful handling.

These changes should resolve the selection problems and make the object picking mechanism more resilient and debuggable.