### PR TITLE
Fix: Ensure cacheDOMElements runs its core logic only once

### DIFF
--- a/src/ui.js
+++ b/src/ui.js
@@ -1,5 +1,7 @@
 // src/ui.js
 
+let domElementsCached = false; // Guard flag for cacheDOMElements
+
 // Store DOM element references
 const domElements = {
   // Header
@@ -61,6 +63,13 @@ const domElements = {
  * Call this once at startup to cache all DOM element references.
  */
 const cacheDOMElements = () => {
+  if (domElementsCached) {
+    console.log('[ui.js] cacheDOMElements: Already cached. Skipping.');
+    return;
+  }
+  console.log('[ui.js] cacheDOMElements: Caching DOM elements now.');
+  domElementsCached = true;
+
   domElements.headerTitle = document.getElementById('header-title');
   domElements.userIdDisplay = document.getElementById('user-id-display');
   domElements.sessionIdDisplay = document.getElementById('session-id-display');


### PR DESCRIPTION
Introduces a guard flag (`domElementsCached`) in `src/ui.js` to prevent the `cacheDOMElements` function from re-populating DOM element references and re-creating dynamic elements (like `backgroundImageFileInput`) if called multiple times.

This addresses an issue identified from logs where `cacheDOMElements` appeared to run twice, potentially leading to event listeners being attached to orphaned elements or incorrect element references. The expectation is that by ensuring single initialization of these critical elements, the 'change' event on the file input will now fire and be handled correctly.