### PR TITLE
fix: Correct redeclaration of imgEntry in canvas.js

### DIFF
--- a/src/canvas.js
+++ b/src/canvas.js
@@ -335,8 +335,8 @@ export const drawVTT = (
         if (!imgEntry)
           loadImage(imageUrl, imageUrl, onDrawNeededCallback);
       }
-      // ---> ADD ERROR DRAWING LOGIC HERE <---
-      const imgEntry = loadedImages.get(imageUrl); // Get it again or use existing reference
+      // ---> ERROR DRAWING LOGIC USES EXISTING imgEntry <---
+      // const imgEntry = loadedImages.get(imageUrl); // This line was removed
       if (imgEntry && imgEntry.status === 'error') {
           // Ensure base styles like fillStyle for text are set if not already
           ctx.strokeStyle = 'red';


### PR DESCRIPTION
This commit resolves a SyntaxError caused by the redeclaration of the constant 'imgEntry' within the drawVTT function in src/canvas.js. The redundant declaration has been removed, and the existing variable is now correctly reused for checking image error status and drawing the error indicator.

This fixes the application breakage reported after the previous set of changes related to object background image handling.